### PR TITLE
Add getDataDW

### DIFF
--- a/src/dataviz/getDataDW.ts
+++ b/src/dataviz/getDataDW.ts
@@ -1,0 +1,88 @@
+import process from "node:process";
+import { csvParse } from "d3-dsv";
+
+/**
+ * Gets the data of a Datawrapper chart, table, or map.
+ *
+ * Authentication is handled via an API key, which can be provided through environment variables (`DATAWRAPPER_KEY`) or explicitly in the options.
+ *
+ * @param chartId - The unique ID of the Datawrapper chart, table, or map. This ID can be found in the Datawrapper URL or dashboard.
+ * @param options - Optional parameters to configure the request.
+ *   @param options.apiKey - The name of the environment variable that stores your Datawrapper API key (e.g., `"DATAWRAPPER_KEY"`). If not provided, the function defaults to looking for the `DATAWRAPPER_KEY` environment variable.
+ *   @param options.parse - If `true`, the response will be parsed and returned as a JavaScript value. CSV data (charts and tables) is returned as an array of objects; JSON data (maps) is returned as a parsed object. Defaults to `false`.
+ *   @param options.returnResponse - If `true`, the function will return the full `Response` object from the Datawrapper API call. This can be useful for debugging or for more detailed handling of the API response. Defaults to `false`.
+ * @returns A Promise that resolves to a raw `string` by default, a parsed value if `parse` is `true` (`Record<string, string>[]` for CSV charts/tables, or a `object` for JSON maps), or a `Response` object if `returnResponse` is `true`.
+ *
+ * @example
+ * ```ts
+ * import { getDataDW } from "journalism-dataviz";
+ *
+ * const data = await getDataDW("myChartId");
+ * console.log(data); // raw CSV string
+ * ```
+ * @example
+ * ```ts
+ * // Parse a chart or table — returns an array of objects (all values are strings).
+ * const rows = await getDataDW("myChartId", { parse: true });
+ * console.log(rows); // [{ salary: "75000", hireDate: "2022-12-15" }, ...]
+ * ```
+ * @example
+ * ```ts
+ * // Parse a locator map — detects JSON automatically and returns a parsed object.
+ * const map = await getDataDW("myMapId", { parse: true });
+ * console.log(map); // { type: "FeatureCollection", features: [...], markers: [] }
+ * ```
+ * @example
+ * ```ts
+ * // If your API key is stored under a different name in process.env (e.g., `DW_KEY`).
+ * const data = await getDataDW("anotherChartId", { apiKey: "DW_KEY" });
+ * console.log(data);
+ * ```
+ * @category Dataviz
+ */
+export default async function getDataDW(
+  chartId: string,
+  options: {
+    apiKey?: string;
+    parse?: boolean;
+    returnResponse?: boolean;
+  } = {},
+): Promise<string | Record<string, string>[] | unknown> {
+  const envVar = options.apiKey ?? "DATAWRAPPER_KEY";
+  const apiKey = process.env[envVar];
+  if (apiKey === undefined || apiKey === "") {
+    throw new Error(`process.env.${envVar} is undefined or ''.`);
+  }
+
+  const response = await fetch(
+    `https://api.datawrapper.de/v3/charts/${chartId}/data`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    },
+  );
+
+  if (options.returnResponse === true) {
+    return response;
+  }
+
+  if (response.status !== 200) {
+    throw new Error(
+      `getDataDW ${chartId}: Upstream HTTP ${response.status} - ${response.statusText}`,
+    );
+  }
+
+  const text = await response.text();
+
+  if (options.parse === true) {
+    const trimmed = text.trimStart();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      return JSON.parse(text);
+    }
+    return csvParse(text) as Record<string, string>[];
+  }
+
+  return text;
+}

--- a/src/dataviz/publishChartDW.ts
+++ b/src/dataviz/publishChartDW.ts
@@ -51,8 +51,6 @@ export default async function publishChartDW(
       },
     },
   );
-  await response.json();
-
   // if returning a response, do it before the response.status checks
   if (options.returnResponse === true) {
     return response;

--- a/src/dataviz/updateAnnotationsDW.ts
+++ b/src/dataviz/updateAnnotationsDW.ts
@@ -183,8 +183,6 @@ export default async function updateAnnotationsDW(
       }),
     },
   );
-  await response.json();
-
   // if returning a response, do it before the response.status checks
   if (options.returnResponse === true) {
     return response;

--- a/src/dataviz/updateNotesDW.ts
+++ b/src/dataviz/updateNotesDW.ts
@@ -63,7 +63,6 @@ export default async function updateNotesDW(
     },
   );
 
-  await response.json();
   // if returning a response, do it before the response.status checks
   if (options.returnResponse === true) {
     return response;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@
  * ```
  */
 
+import getDataDW from "./dataviz/getDataDW.ts";
 import updateDataDW from "./dataviz/updateDataDW.ts";
 import updateAnnotationsDW from "./dataviz/updateAnnotationsDW.ts";
 import updateNotesDW from "./dataviz/updateNotesDW.ts";
@@ -35,6 +36,7 @@ import saveChart from "./dataviz/saveChart.ts";
 import rewind from "./dataviz/rewind.ts";
 
 export {
+  getDataDW,
   logBarChart,
   logDotChart,
   logLineChart,

--- a/test/dataviz/getDataDW.test.ts
+++ b/test/dataviz/getDataDW.test.ts
@@ -1,0 +1,91 @@
+import "@std/dotenv/load";
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+import { dataAsCsv } from "@nshiab/journalism-format";
+import getDataDW from "../../src/dataviz/getDataDW.ts";
+import updateDataDW from "../../src/dataviz/updateDataDW.ts";
+
+const chartData = [{ salary: 75000, hireDate: new Date("2022-12-15") }];
+const chartDataCsv = dataAsCsv(chartData);
+
+const mapData = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        coordinates: [
+          [
+            [11.127454320325711, 20.34856592751224],
+            [11.127454320325711, -13.781306861158996],
+            [55.68071875381875, -13.781306861158996],
+            [55.68071875381875, 20.34856592751224],
+            [11.127454320325711, 20.34856592751224],
+          ],
+        ],
+        type: "Polygon",
+      },
+    },
+  ],
+};
+
+const apiKey = Deno.env.get("DATAWRAPPER_KEY");
+if (typeof apiKey === "string" && apiKey !== "") {
+  Deno.test("should get data from a chart", async () => {
+    await updateDataDW("ntURh", chartDataCsv);
+    const data = await getDataDW("ntURh");
+
+    assertStringIncludes(data as string, "salary");
+    assertStringIncludes(data as string, "75000");
+    assertStringIncludes(data as string, "2022-12-15");
+  });
+
+  Deno.test("should get data from a chart parsed as rows", async () => {
+    await updateDataDW("ntURh", chartDataCsv);
+    const rows = await getDataDW("ntURh", { parse: true });
+
+    assertEquals((rows as Record<string, string>[])[0], {
+      salary: "75000",
+      hireDate: "2022-12-15",
+    });
+  });
+
+  Deno.test("should get data from a map", async () => {
+    await updateDataDW("lDO6F", JSON.stringify(mapData));
+    const data = await getDataDW("lDO6F");
+
+    assertStringIncludes(data as string, "FeatureCollection");
+    assertStringIncludes(data as string, "Polygon");
+  });
+
+  Deno.test("should get data from a map parsed as an object", async () => {
+    await updateDataDW("lDO6F", JSON.stringify(mapData));
+    const data = await getDataDW("lDO6F", { parse: true });
+
+    assertEquals((data as typeof mapData).type, "FeatureCollection");
+    assertEquals((data as typeof mapData).features[0].geometry.type, "Polygon");
+  });
+
+  Deno.test("should return a Response when returnResponse is true", async () => {
+    const response = await getDataDW("ntURh", { returnResponse: true });
+
+    assertEquals(response instanceof Response, true);
+    assertEquals((response as Response).status, 200);
+  });
+} else {
+  console.log("No DATAWRAPPER_KEY in process.env");
+}
+
+const differentApiKey = Deno.env.get("DW_KEY");
+if (typeof differentApiKey === "string" && differentApiKey !== "") {
+  Deno.test("should get data from a chart with a specific API key", async () => {
+    await updateDataDW("ntURh", chartDataCsv, { apiKey: "DW_KEY" });
+    const data = await getDataDW("ntURh", { apiKey: "DW_KEY" });
+
+    assertStringIncludes(data as string, "salary");
+    assertStringIncludes(data as string, "75000");
+    assertStringIncludes(data as string, "2022-12-15");
+  });
+} else {
+  console.log("No DW_KEY in process.env");
+}


### PR DESCRIPTION
Closes #16

## Summary

- Adds `getDataDW` to retrieve the data of a Datawrapper chart, table, or map
- With `parse: true`, auto-detects the format and returns parsed rows (`Record<string, string>[]` for CSV) or a parsed object for JSON map data
- Fixes a bug in `publishChartDW`, `updateAnnotationsDW`, and `updateNotesDW` where `response.json()` was called before the `returnResponse` check, consuming the body stream before it could be returned to the caller
